### PR TITLE
Fix Prisma client imports

### DIFF
--- a/actions/getTransactions.ts
+++ b/actions/getTransactions.ts
@@ -1,4 +1,4 @@
-import { Transaction } from "@/lib/generated/prisma";
+import type { Transaction } from "@prisma/client";
 import axios from "axios"
 
 

--- a/components/transaction-list.tsx
+++ b/components/transaction-list.tsx
@@ -1,7 +1,7 @@
 import { ArrowUp, ArrowDown, RotateCcw } from "lucide-react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Transaction } from "@/lib/generated/prisma"
+import type { Transaction } from "@prisma/client"
 
 interface TransactionListProps {
   title: string

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
-import { PrismaClient } from "@/lib/generated/prisma";
+import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 export const auth = betterAuth({

--- a/lib/prismadb.ts
+++ b/lib/prismadb.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@/lib/generated/prisma";
+import { PrismaClient } from "@prisma/client";
 
 declare global {
     var prisma: PrismaClient | undefined


### PR DESCRIPTION
## Summary
- use `@prisma/client` directly instead of missing local client

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851545d26d8832fb632af1e821090b4