### PR TITLE
Add Vitest setup and date utility tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,12 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+# Running Tests
+
+This project uses [Vitest](https://vitest.dev) for unit tests. After installing dependencies, run:
+
+```bash
+npm test
+```
+
 # finance-dashboard

--- a/components/transaction-form.tsx
+++ b/components/transaction-form.tsx
@@ -191,30 +191,3 @@ export function TransactionForm({ onTransactionAdded }: TransactionFormProps) {
         </div>
     )
 }
-
-// Helper functions for date formatting
-function formatDateToDDMMYYYY(date: Date): string {
-    const day = String(date.getDate()).padStart(2, '0');
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const year = date.getFullYear();
-    return `${day}-${month}-${year}`;
-}
-
-function parseDateFromDDMMYYYY(dateStr: string): Date | undefined {
-    if (!dateStr) return undefined;
-    
-    // Handle both DD-MM-YYYY and DD/MM/YYYY formats
-    const parts = dateStr.split(/[-\/]/);
-    if (parts.length !== 3) return undefined;
-    
-    const [day, month, year] = parts.map(Number);
-    if (!day || !month || !year) return undefined;
-    
-    // Create date with explicit year, month (0-based), day
-    const date = new Date(year, month - 1, day);
-    
-    // Validate the date
-    if (isNaN(date.getTime())) return undefined;
-    
-    return date;
-}

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -1,0 +1,21 @@
+export function formatDateToDDMMYYYY(date: Date): string {
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const year = date.getFullYear();
+  return `${day}-${month}-${year}`;
+}
+
+export function parseDateFromDDMMYYYY(dateStr: string): Date | undefined {
+  if (!dateStr) return undefined;
+
+  const parts = dateStr.split(/[-\/]/);
+  if (parts.length !== 3) return undefined;
+
+  const [day, month, year] = parts.map(Number);
+  if (!day || !month || !year) return undefined;
+
+  const date = new Date(year, month - 1, day);
+  if (isNaN(date.getTime())) return undefined;
+
+  return date;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
@@ -45,6 +46,7 @@
     "prisma": "^6.9.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.4",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^1.4.0"
   }
 }

--- a/tests/date-utils.test.ts
+++ b/tests/date-utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { formatDateToDDMMYYYY, parseDateFromDDMMYYYY } from '../lib/date-utils'
+
+describe('formatDateToDDMMYYYY', () => {
+  it('formats a valid date', () => {
+    const date = new Date(2023, 11, 25)
+    expect(formatDateToDDMMYYYY(date)).toBe('25-12-2023')
+  })
+})
+
+describe('parseDateFromDDMMYYYY', () => {
+  it('parses valid hyphenated date', () => {
+    const result = parseDateFromDDMMYYYY('25-12-2023')
+    expect(result).toEqual(new Date(2023, 11, 25))
+  })
+
+  it('parses valid slash date', () => {
+    const result = parseDateFromDDMMYYYY('01/01/2023')
+    expect(result).toEqual(new Date(2023, 0, 1))
+  })
+
+  it('returns undefined for invalid date', () => {
+    expect(parseDateFromDDMMYYYY('32-01-2023')).toBeUndefined()
+  })
+
+  it('returns undefined for malformed input', () => {
+    expect(parseDateFromDDMMYYYY('invalid')).toBeUndefined()
+    expect(parseDateFromDDMMYYYY('12-2023')).toBeUndefined()
+    expect(parseDateFromDDMMYYYY('')).toBeUndefined()
+  })
+})

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- add `formatDateToDDMMYYYY` and `parseDateFromDDMMYYYY` helpers under `lib`
- remove the unused helper implementations from `transaction-form`
- introduce Vitest configuration and tsconfig for tests
- create a unit test covering date utility helpers
- document how to run the test suite

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685155887400832f9f0cd559fd69a6ec