### PR TITLE
Create missing dashboard pages and analytics

### DIFF
--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -1,0 +1,11 @@
+import { AnalyticsTracker } from "@/components/analytics-tracker";
+
+export default function AnalyticsPage() {
+  return (
+    <div className="p-6 w-full">
+      <AnalyticsTracker page="/dashboard/analytics" />
+      <h1 className="text-2xl font-bold mb-4">Analytics</h1>
+      <p>Explore analytics and charts about your finances.</p>
+    </div>
+  );
+}

--- a/app/dashboard/finance/page.tsx
+++ b/app/dashboard/finance/page.tsx
@@ -1,0 +1,11 @@
+import { AnalyticsTracker } from "@/components/analytics-tracker";
+
+export default function FinancePage() {
+  return (
+    <div className="p-6 w-full">
+      <AnalyticsTracker page="/dashboard/finance" />
+      <h1 className="text-2xl font-bold mb-4">Finance</h1>
+      <p>Manage your accounts and financial data here.</p>
+    </div>
+  );
+}

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -1,0 +1,11 @@
+import { AnalyticsTracker } from "@/components/analytics-tracker";
+
+export default function ProfilePage() {
+  return (
+    <div className="p-6 w-full">
+      <AnalyticsTracker page="/dashboard/profile" />
+      <h1 className="text-2xl font-bold mb-4">Profile</h1>
+      <p>Update your profile information here.</p>
+    </div>
+  );
+}

--- a/app/dashboard/reports/page.tsx
+++ b/app/dashboard/reports/page.tsx
@@ -1,0 +1,11 @@
+import { AnalyticsTracker } from "@/components/analytics-tracker";
+
+export default function ReportsPage() {
+  return (
+    <div className="p-6 w-full">
+      <AnalyticsTracker page="/dashboard/reports" />
+      <h1 className="text-2xl font-bold mb-4">Reports</h1>
+      <p>Generate and view financial reports here.</p>
+    </div>
+  );
+}

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,0 +1,11 @@
+import { AnalyticsTracker } from "@/components/analytics-tracker";
+
+export default function SettingsPage() {
+  return (
+    <div className="p-6 w-full">
+      <AnalyticsTracker page="/dashboard/settings" />
+      <h1 className="text-2xl font-bold mb-4">Settings</h1>
+      <p>Configure your dashboard preferences here.</p>
+    </div>
+  );
+}

--- a/app/dashboard/transactions/page.tsx
+++ b/app/dashboard/transactions/page.tsx
@@ -1,0 +1,11 @@
+import { AnalyticsTracker } from "@/components/analytics-tracker";
+
+export default function TransactionsPage() {
+  return (
+    <div className="p-6 w-full">
+      <AnalyticsTracker page="/dashboard/transactions" />
+      <h1 className="text-2xl font-bold mb-4">Transactions</h1>
+      <p>View and record your transactions here.</p>
+    </div>
+  );
+}

--- a/components/analytics-tracker.tsx
+++ b/components/analytics-tracker.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { useEffect } from "react";
+import { trackPageView } from "@/lib/analytics";
+
+interface AnalyticsTrackerProps {
+  page: string;
+}
+
+export function AnalyticsTracker({ page }: AnalyticsTrackerProps) {
+  useEffect(() => {
+    trackPageView(page);
+  }, [page]);
+  return null;
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,5 @@
+export function trackPageView(page: string) {
+  if (typeof window !== "undefined") {
+    console.log(`[Analytics] Page view: ${page}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple analytics utility and tracker component
- create placeholder dashboard pages referenced in the sidebar
- instrument each new page with analytics tracking

## Testing
- `npm test` *(fails: Failed to load PostCSS config)*
